### PR TITLE
docs: fix typo in C++ basics heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ This repository contains examples and exercises for modern C++ programming, trac
 ## Table of Contents
 - [Modern C++ Programming](#modern-c-programming)
   - [Table of Contents](#table-of-contents)
-  - [Basic of C++](#basic-of-c)
+  - [Basics of C++](#basics-of-c)
 
-## Basic of C++
+## Basics of C++
 
 This section covers the fundamental concepts of C++ programming.
 


### PR DESCRIPTION
## Summary
- fix README to say "Basics of C++" in TOC and heading

## Testing
- `g++ -std=c++17 day01.cpp -o day01 && ./day01`
- `g++ -std=c++17 day02.cpp -o day02 && ./day02` (fails: munmap_chunk invalid pointer)
- `g++ -std=c++17 day03.cpp -o day03 && ./day03`
- `g++ -std=c++17 day04.cpp -o day04 && ./day04`


------
https://chatgpt.com/codex/tasks/task_e_6894bae228dc832794f4f81e9804626b